### PR TITLE
Fix view

### DIFF
--- a/src/app/protected/cranix/system/config/system-config.component.html
+++ b/src/app/protected/cranix/system/config/system-config.component.html
@@ -30,7 +30,7 @@
               disabled="{{config.readOnly == 'yes'}}" (ionChange)="togle(config.key,$event)">
             </ion-toggle>
           </ion-item>
-          <ion-item *ngIf="config.type == 'string'">
+          <ion-item *ngIf="config.type.substring(0,6) == 'string'">
             <ion-input type="text" value="{{config.value}}" disabled="{{config.readOnly == 'yes'}}" id="{{config.key}}">
             </ion-input>
             <ion-button *ngIf="config.readOnly == 'no'" slot="end" fill="clear" size="small" (click)="save(config.key)">


### PR DESCRIPTION
Some configuration values from types like string(dns,proxy), string(telex,simple) or string(primary) are not visible in the system menu.